### PR TITLE
feat: 添加充电状态相关传感器

### DIFF
--- a/custom_components/wuling/__init__.py
+++ b/custom_components/wuling/__init__.py
@@ -20,6 +20,8 @@ from homeassistant.const import (
     UnitOfPressure,
     UnitOfTemperature,
     UnitOfElectricPotential,
+    UnitOfElectricCurrent,
+    UnitOfTime,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.entity import DeviceInfo
@@ -222,6 +224,20 @@ class StateCoordinator(DataUpdateCoordinator):
             BinarySensorConv('plugging', prop='carStatus.vecChrgingSts').with_option({
                 'icon': 'mdi:power-plug',
                 'device_class': BinarySensorDeviceClass.PLUG,
+            }),
+            BinarySensorConv('vec_charge_sts', prop='carStatus.vecChargeSts').with_option({
+                'device_class': BinarySensorDeviceClass.BATTERY_CHARGING,
+            }),
+            NumberSensorConv('left_charge_time', prop='carStatus.leftChargeTime').with_option({
+                'icon': 'mdi:timer-sand',
+                'state_class': SensorStateClass.MEASUREMENT,
+                'unit_of_measurement': UnitOfTime.MINUTES,
+            }),
+            NumberSensorConv('charging_current', prop='carStatus.obcOtpCur').with_option({
+                'icon': 'mdi:current-ac',
+                'state_class': SensorStateClass.MEASUREMENT,
+                'device_class': SensorDeviceClass.CURRENT,
+                'unit_of_measurement': UnitOfElectricCurrent.AMPERE,
             }),
             MapSensorConv('key_status', prop='carStatus.keyStatus', map={
                 '0': '无钥匙',

--- a/custom_components/wuling/translations/en.json
+++ b/custom_components/wuling/translations/en.json
@@ -126,6 +126,15 @@
       "plugging": {
         "name": "充电枪状态"
       },
+      "vec_charge_sts": {
+        "name": "否正在充电"
+      },
+      "left_charge_time": {
+        "name": "剩余充电时间"
+      },
+      "charging_current": {
+        "name": "当前充电电流"
+      },
       "ac_status": {
         "name": "空调状态"
       },


### PR DESCRIPTION
新增三个传感器以提供更详细的充电信息：
- 二进制传感器 'vec_charge_sts' 用于检测车辆是否正在充电
- 数值传感器 'left_charge_time' 显示剩余充电时间（分钟）
- 数值传感器 'charging_current' 显示当前充电电流（安培）

同时更新英文翻译文件以匹配新增传感器。